### PR TITLE
Wrap arrays when parameters of a method

### DIFF
--- a/lib/src/main/java/com/genymobile/mirror/MirrorHandler.java
+++ b/lib/src/main/java/com/genymobile/mirror/MirrorHandler.java
@@ -167,6 +167,9 @@ public class MirrorHandler<T> implements InvocationHandler {
     }
 
     private java.lang.Class unwrapParameterArray(java.lang.Class clazz) {
+        if (clazz.getComponentType().isPrimitive()) {
+            return clazz;
+        }
         return Array.newInstance(unwrapParameterType(clazz.getComponentType()), 0).getClass();
     }
 
@@ -183,7 +186,8 @@ public class MirrorHandler<T> implements InvocationHandler {
 
     private Object unwrap(Object object) {
         if (object.getClass().isArray()) {
-            return unwrapArray((Object[]) object);
+            return object.getClass().getComponentType().isPrimitive() ?
+                    object : unwrapArray((Object[]) object);
         }
         return unwrapObject(object);
     }

--- a/lib/src/test/java/com/genymobile/mirror/MethodTest.java
+++ b/lib/src/test/java/com/genymobile/mirror/MethodTest.java
@@ -69,4 +69,12 @@ public class MethodTest {
 
         assert(result == 5);
     }
+
+    @Test
+    public void checkThatPassingPrimitiveAsParameterDoNotUnwrapThem() {
+        long[] array = new long[5];
+        int result = dummy.doNotUnwrapPrimiteAndReturnArraySize(array);
+
+        assert(result == 5);
+    }
 }

--- a/lib/src/test/java/com/genymobile/mirror/mock/PublicDummy.java
+++ b/lib/src/test/java/com/genymobile/mirror/mock/PublicDummy.java
@@ -45,4 +45,6 @@ public interface PublicDummy {
     void doStuff(PrivateDummy privateDummy);
 
     int unwrapParametersAndReturnArraySize(PrivateDummy[] privateDummies);
+
+    int doNotUnwrapPrimiteAndReturnArraySize(long[] privateDummies);
 }

--- a/lib/src/test/java/com/genymobile/mirror/target/PublicDummyClass.java
+++ b/lib/src/test/java/com/genymobile/mirror/target/PublicDummyClass.java
@@ -29,4 +29,7 @@ public class PublicDummyClass {
     int unwrapParametersAndReturnArraySize(PrivateDummyClass[] privateDummies){
         return privateDummies.length;
     }
+    int doNotUnwrapPrimiteAndReturnArraySize(long[] primitives){
+        return primitives.length;
+    }
 }


### PR DESCRIPTION
My brain hurts : Wrap the arrays.

Code is ugly and needs a refactoring. But at least it's working now, and i don't see any other use case (except uncommon one) where mirror doesn't work. This PR fixes #4.

BUT, we cannot keep the code like this MirrorHandler is too big. Next step : Huge refactoring.
