### PR TITLE
Allow instance to be a subclass of the declared target

### DIFF
--- a/lib/src/main/java/com/genymobile/mirror/MirrorHandler.java
+++ b/lib/src/main/java/com/genymobile/mirror/MirrorHandler.java
@@ -50,7 +50,7 @@ public class MirrorHandler implements InvocationHandler {
                 ensureObjectClass();
                 return this.object;
             } else {
-                throw new MirrorException("Missing object", new Throwable());
+                throw new MirrorException("Missing instance object");
             }
         }
 
@@ -124,8 +124,8 @@ public class MirrorHandler implements InvocationHandler {
     }
 
     private void ensureObjectClass() {
-        if (object != null && object.getClass() != clazz) {
-            throw new MirrorException("Class doesn't match", new Throwable());
+        if (object != null && !clazz.isInstance(object)) {
+            throw new MirrorException("Class doesn't match: instance should be " + clazz + " but is " + object.getClass());
         }
     }
 


### PR DESCRIPTION
This is usefull when you just know the base class or interface of the target.
